### PR TITLE
chore: Reduce size by using alpine jre base image

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ Compile / mainClass  := Some("swiss.dasch.shacl.cli.Main")
 Docker / packageName := "daschswiss/shacl-cli"
 dockerExposedPorts ++= Seq()
 
-dockerBaseImage       := "eclipse-temurin:21"
+dockerBaseImage       := "eclipse-temurin:21-jre"
 dockerBuildxPlatforms := Seq("linux/arm64/v8", "linux/amd64")
 dockerUpdateLatest    := true
 

--- a/build.sbt
+++ b/build.sbt
@@ -41,9 +41,14 @@ Compile / mainClass  := Some("swiss.dasch.shacl.cli.Main")
 Docker / packageName := "daschswiss/shacl-cli"
 dockerExposedPorts ++= Seq()
 
-dockerBaseImage       := "eclipse-temurin:21-jre"
+dockerBaseImage       := "eclipse-temurin:21-jre-alpine"
 dockerBuildxPlatforms := Seq("linux/arm64/v8", "linux/amd64")
 dockerUpdateLatest    := true
+dockerCommands ++= Seq(
+  Cmd("USER", "root"),
+  Cmd("RUN", "apk add --no-cache bash"),
+  Cmd("USER", "1001:0")
+)
 
 val gitCommit = ("git rev-parse HEAD" !!).trim
 val gitBranch = Option("git rev-parse --abbrev-ref HEAD" !!)


### PR DESCRIPTION

- **chore: Reduce size by using alpine jre base image**

Cuts down the size of the container to ~360MB.