### PR TITLE
fix: Surface Docker mount write failures on stderr

### DIFF
--- a/scripts/it/docker-it.sh
+++ b/scripts/it/docker-it.sh
@@ -25,7 +25,7 @@ CONFORMS_TRUE_RE='sh:conforms[[:space:]]+true'
 CONFORMS_FALSE_RE='sh:conforms[[:space:]]+false'
 
 run_scenario() {
-  local name="$1" shapes_fixture="$2" data_fixture="$3"
+  local name="$1" shapes_fixture="$2" data_fixture="$3" mount_opts="${4:-}"
   local tmp stdout_f stderr_f rc=0
   tmp="$(mktemp -d)"
   stdout_f="$(mktemp)"
@@ -39,7 +39,7 @@ run_scenario() {
   cp "$FIXTURES_DIR/$data_fixture"   "$tmp/data.ttl"
   chmod 777 "$tmp"
 
-  docker run --rm -v "$tmp:/data" "$IMAGE" \
+  docker run --rm -v "$tmp:/data${mount_opts}" "$IMAGE" \
     validate --shacl /data/shapes.ttl --data /data/data.ttl --report /data/report.ttl \
     >"$stdout_f" 2>"$stderr_f" || rc=$?
 
@@ -59,14 +59,19 @@ run_scenario() {
       _assert "$name" "sh:conforms false"         "grep -qE '$CONFORMS_FALSE_RE' '$tmp/report.ttl'"    || scenario_ok=0
       ;;
     invalid-input)
-      # NOTE: The container currently emits diagnostics to stdout rather than
-      # stderr (see dsp-tools silent-failure report). This assertion is
-      # intentionally permissive — it accepts a diagnostic on either stream —
-      # so it catches the *pathological* case (truly silent non-zero exit) but
-      # tolerates the known channel-routing wart. Tighten to `stderr non-empty`
-      # once the logging channel fix ships.
-      _assert "$name" "exit non-zero"             "[ $rc -ne 0 ]"                                                       || scenario_ok=0
-      _assert "$name" "diagnostic on some stream" "[ -s '$stderr_f' ] || [ -s '$stdout_f' ]"                            || scenario_ok=0
+      _assert "$name" "exit non-zero"             "[ $rc -ne 0 ]"                      || scenario_ok=0
+      _assert "$name" "stderr non-empty"          "[ -s '$stderr_f' ]"                 || scenario_ok=0
+      ;;
+    bad-mount-readonly)
+      # Inputs mount correctly but the bind is read-only, so writing the report
+      # fails inside the container. Asserts the fix for the Band C silent-write
+      # failure: exit non-zero AND a real diagnostic on stderr (previously just
+      # an empty ANSI-colored line went to stdout and nothing to stderr).
+      _assert "$name" "exit non-zero"             "[ $rc -ne 0 ]"                      || scenario_ok=0
+      _assert "$name" "stderr non-empty"          "[ -s '$stderr_f' ]"                 || scenario_ok=0
+      _assert "$name" "FileNotFoundException on stderr" \
+                                                  "grep -q 'FileNotFoundException' '$stderr_f'" || scenario_ok=0
+      _assert "$name" "no report written"         "[ ! -f '$tmp/report.ttl' ]"         || scenario_ok=0
       ;;
     *)
       echo "INTERNAL: unknown scenario $name" >&2
@@ -101,10 +106,13 @@ _assert() {
 }
 
 echo "Using image: $IMAGE"
-run_scenario conforming     shapes.ttl         data-conforming.ttl
-run_scenario non-conforming shapes.ttl         data-nonconforming.ttl
+run_scenario conforming         shapes.ttl         data-conforming.ttl
+run_scenario non-conforming     shapes.ttl         data-nonconforming.ttl
 # invalid-input: the SUT here is the invalid SHACL file; data-conforming.ttl
 # is a throwaway valid data argument, not part of the assertion.
-run_scenario invalid-input  shapes-invalid.ttl data-conforming.ttl
+run_scenario invalid-input      shapes-invalid.ttl data-conforming.ttl
+# bad-mount-readonly: valid inputs, but the bind mount is read-only so the
+# report write fails. The `:ro` mount option is passed as the 4th argument.
+run_scenario bad-mount-readonly shapes.ttl         data-conforming.ttl :ro
 
 exit "$FAIL"

--- a/scripts/it/docker-it.sh
+++ b/scripts/it/docker-it.sh
@@ -25,7 +25,7 @@ CONFORMS_TRUE_RE='sh:conforms[[:space:]]+true'
 CONFORMS_FALSE_RE='sh:conforms[[:space:]]+false'
 
 run_scenario() {
-  local name="$1" shapes_fixture="$2" data_fixture="$3" mount_opts="${4:-}"
+  local name="$1" shapes_fixture="$2" data_fixture="$3" mount_opts="${4:-}" report_path="${5:-/data/report.ttl}"
   local tmp stdout_f stderr_f rc=0
   tmp="$(mktemp -d)"
   stdout_f="$(mktemp)"
@@ -40,7 +40,7 @@ run_scenario() {
   chmod 777 "$tmp"
 
   docker run --rm -v "$tmp:/data${mount_opts}" "$IMAGE" \
-    validate --shacl /data/shapes.ttl --data /data/data.ttl --report /data/report.ttl \
+    validate --shacl /data/shapes.ttl --data /data/data.ttl --report "$report_path" \
     >"$stdout_f" 2>"$stderr_f" || rc=$?
 
   # Assert per-scenario expectations.
@@ -62,11 +62,17 @@ run_scenario() {
       _assert "$name" "exit non-zero"             "[ $rc -ne 0 ]"                      || scenario_ok=0
       _assert "$name" "stderr non-empty"          "[ -s '$stderr_f' ]"                 || scenario_ok=0
       ;;
-    bad-mount-readonly)
-      # Inputs mount correctly but the bind is read-only, so writing the report
-      # fails inside the container. Asserts the fix for the Band C silent-write
-      # failure: exit non-zero AND a real diagnostic on stderr (previously just
-      # an empty ANSI-colored line went to stdout and nothing to stderr).
+    bad-mount-readonly | bad-mount-wrong-target)
+      # bad-mount-readonly:    inputs mount correctly but the bind is read-only,
+      #                        so writing the report fails with "Read-only file
+      #                        system".
+      # bad-mount-wrong-target: inputs mount correctly but the report path points
+      #                         outside any bind mount — FileOutputStream fails
+      #                         with "No such file or directory".
+      #
+      # Both assert the fix for the Band C silent-write failure: exit non-zero
+      # AND a real diagnostic on stderr (previously just an empty ANSI-colored
+      # line went to stdout and nothing to stderr).
       _assert "$name" "exit non-zero"             "[ $rc -ne 0 ]"                      || scenario_ok=0
       _assert "$name" "stderr non-empty"          "[ -s '$stderr_f' ]"                 || scenario_ok=0
       _assert "$name" "FileNotFoundException on stderr" \
@@ -113,6 +119,11 @@ run_scenario non-conforming     shapes.ttl         data-nonconforming.ttl
 run_scenario invalid-input      shapes-invalid.ttl data-conforming.ttl
 # bad-mount-readonly: valid inputs, but the bind mount is read-only so the
 # report write fails. The `:ro` mount option is passed as the 4th argument.
-run_scenario bad-mount-readonly shapes.ttl         data-conforming.ttl :ro
+run_scenario bad-mount-readonly    shapes.ttl data-conforming.ttl :ro
+# bad-mount-wrong-target: valid inputs at /data, but --report points outside
+# any mount (`/elsewhere/report.ttl`). Simulates the user mounting the output
+# volume at a path that doesn't match their --report argument. The 5th arg
+# overrides the report path.
+run_scenario bad-mount-wrong-target shapes.ttl data-conforming.ttl "" /elsewhere/report.ttl
 
 exit "$FAIL"

--- a/src/main/scala/swiss/dasch/shacl/cli/Main.scala
+++ b/src/main/scala/swiss/dasch/shacl/cli/Main.scala
@@ -45,15 +45,17 @@ object Main extends ZIOCliDefault {
     summary = text("Validate SHACL shapes against data files"),
     command = command,
   ) { case (validateShapes, reportDetails, addBlankNodes, shaclFile, dataFile, reportFile) =>
-    ZIO.scoped {
-      for {
-        shapes     <- ZIO.fromAutoCloseable(ZIO.succeed(new FileInputStream(shaclFile.toFile)))
-        data       <- ZIO.fromAutoCloseable(ZIO.succeed(new FileInputStream(dataFile.toFile)))
-        reportPath <- ZIO.fromAutoCloseable(ZIO.succeed(new FileOutputStream(reportFile.toFile)))
-        report     <- validator.validate(data, shapes, ValidationOptions(validateShapes, reportDetails, addBlankNodes))
-        _          <- ZIO.attemptBlockingIO(RDFDataMgr.write(reportPath, report.getModel, RDFFormat.TURTLE))
-        _          <- ZIO.logInfo(s"Validation report written to ${reportFile.toAbsolutePath}")
-      } yield 1
-    }
+    ZIO
+      .scoped {
+        for {
+          shapes     <- ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(new FileInputStream(shaclFile.toFile)))
+          data       <- ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(new FileInputStream(dataFile.toFile)))
+          reportPath <- ZIO.fromAutoCloseable(ZIO.attemptBlockingIO(new FileOutputStream(reportFile.toFile)))
+          report     <- validator.validate(data, shapes, ValidationOptions(validateShapes, reportDetails, addBlankNodes))
+          _          <- ZIO.attemptBlockingIO(RDFDataMgr.write(reportPath, report.getModel, RDFFormat.TURTLE))
+          _          <- ZIO.logInfo(s"Validation report written to ${reportFile.toAbsolutePath}")
+        } yield 1
+      }
+      .onError(cause => Console.printLineError(cause.prettyPrint).orDie)
   }
 }


### PR DESCRIPTION
When the Docker bind mount is read-only or the `--report` path points outside any mount, the CLI used to exit non-zero with an empty ANSI-colored line on stdout and nothing on stderr. Downstream consumers (notably dsp-tools) had no way to diagnose the failure and surfaced a generic "Docker command failed" message.

Root cause: `FileOutputStream` was wrapped in `ZIO.succeed`, so the thrown `FileNotFoundException` became an unhandled defect that the console logger rendered as an empty message.

Switching to `ZIO.attemptBlockingIO` plus an `.onError` tap that writes the cause to stderr makes the real diagnostic (e.g. "Read-only file system", "No such file or directory") visible to callers and to the dsp-tools PR that forwards stdout/stderr into its error message.

Integration-test coverage is extended with two bad-mount scenarios and the previously permissive `invalid-input` assertion is tightened to require stderr non-empty.